### PR TITLE
Add README.md for SQL Talk project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# sql_talk
+# SQL Talk
+
+## Description
+SQL Talk is a tool designed to allow users to interact with SQL databases using natural language queries. It aims to simplify database interaction by translating plain English questions into SQL commands, making data retrieval and analysis more accessible to users without extensive SQL knowledge.
+
+## Features
+*   **Natural Language Processing:** Converts natural language questions into SQL queries.
+*   **Database Compatibility:** Aims to support a variety of popular SQL databases.
+*   **User-Friendly Interface:** Provides an intuitive interface for users to input queries and view results.
+*   **Query History:** (Potential Feature) Keeps a history of queries for easy reference.
+*   **Export Options:** (Potential Feature) Allows users to export query results in various formats (e.g., CSV, JSON).
+
+## Getting Started
+
+### Prerequisites
+*   [List any prerequisites here, e.g., Python 3.x, Node.js, specific database drivers]
+
+### Installation
+1.  Clone the repository:
+    ```bash
+    git clone <repository-url>
+    ```
+2.  Navigate to the project directory:
+    ```bash
+    cd sql_talk
+    ```
+3.  Install dependencies:
+    ```bash
+    # Add specific instructions for installing dependencies
+    # For example:
+    # pip install -r requirements.txt
+    # npm install
+    ```
+
+### Configuration
+*   [Provide details on how to configure the application, e.g., database connection strings, API keys]
+
+## Usage
+Once the application is set up and running, you can start asking questions in natural language.
+
+**Example:**
+*   "Show me all customers from London"
+*   "What are the total sales for the last quarter?"
+*   "List products with less than 10 units in stock"
+
+The application will translate these questions into SQL queries and display the results.
+
+## Contributing
+Contributions are welcome! If you'd like to contribute to SQL Talk, please follow these steps:
+
+1.  Fork the repository.
+2.  Create a new branch for your feature or bug fix:
+    ```bash
+    git checkout -b feature/your-feature-name
+    ```
+3.  Make your changes and commit them with clear and concise messages.
+4.  Push your changes to your forked repository.
+5.  Create a pull request to the main repository's `main` branch.
+
+Please ensure your code adheres to the project's coding standards and includes relevant tests if applicable.
+
+*(Note: This README is based on the general understanding of a "SQL Talk" application. Specific details about the original GCP SQL Talk project were not available. Please update this README with accurate information if you have it.)*


### PR DESCRIPTION
This commit adds a README.md file to the SQL Talk project. Since specific details about the original GCP SQL Talk project were unavailable, this README provides a general overview, potential features, and placeholder sections for getting started, usage, and contributions.